### PR TITLE
Create a listing tasks route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ watch:
 	@poetry run ptw -c -w -- --quiet --nf --cov=fastlane tests/
 
 run:
-	@fastlane api -vvv -c ./fastlane/config/local.conf
+	@poetry run fastlane api -vvv -c ./fastlane/config/local.conf
 
 worker:
 	@#This env must be set in MacOS to ensure that docker py works

--- a/fastlane/api/enqueue.py
+++ b/fastlane/api/enqueue.py
@@ -158,7 +158,6 @@ def create_task(task_id):
     )
 
     job_url = url_for("task.get_job", task_id=task_id, job_id=job_id, _external=True)
-    task_url = url_for("task.get_task", task_id=task_id, _external=True)
 
     return jsonify(
         {
@@ -166,6 +165,6 @@ def create_task(task_id):
             "jobId": job_id,
             "queueJobId": queue_job_id,
             "jobUrl": job_url,
-            "taskUrl": task_url,
+            "taskUrl": task.get_url(),
         }
     )

--- a/fastlane/config/__init__.py
+++ b/fastlane/config/__init__.py
@@ -145,3 +145,10 @@ Config.define(
     "From E-mail of the SMTP server used to send notifications",
     "Email",
 )
+
+Config.define(
+    "PAGINATION_PER_PAGE",
+    10,
+    "Total items per page to be used on api pagination methods",
+    "API",
+)

--- a/fastlane/models/task.py
+++ b/fastlane/models/task.py
@@ -4,6 +4,7 @@ import datetime
 # 3rd Party
 import mongoengine.errors
 from bson.objectid import ObjectId
+from flask import url_for
 from mongoengine import DateTimeField, ListField, ReferenceField, StringField
 
 # Fastlane
@@ -37,12 +38,30 @@ class Task(db.Document):
 
         return super(Task, self).save(*args, **kwargs)
 
+    def get_url(self):
+        return url_for("task.get_task", task_id=self.task_id, _external=True)
+
+    def to_dict(self):
+        res = {
+            'taskId': self.task_id,
+            'createdAt': self.created_at.timestamp(),
+            'lastModifiedAt': self.last_modified_at.timestamp(),
+            'url': self.get_url(),
+            'jobsCount': len(self.jobs),
+        }
+
+        return res
+
     @classmethod
     def create_task(cls, task_id):
         t = cls(task_id=task_id)
         t.save()
 
         return t
+
+    @classmethod
+    def get_tasks(cls, page=1, per_page=20):
+        return cls.objects.paginate(page, per_page)
 
     @classmethod
     def get_by_task_id(cls, task_id):

--- a/tests/api/test_enqueue.py
+++ b/tests/api/test_enqueue.py
@@ -16,9 +16,7 @@ from fastlane.models.task import Task
 def test_enqueue1(client):
     """Test enqueue a job works"""
     task_id = str(uuid4())
-
     data = {"image": "ubuntu", "command": "ls"}
-
     rv = client.post(f"/tasks/{task_id}", data=dumps(data), follow_redirects=True)
 
     expect(rv.status_code).to_equal(200)
@@ -28,9 +26,14 @@ def test_enqueue1(client):
     expect(job_id).not_to_be_null()
     expect(obj["queueJobId"]).not_to_be_null()
 
+    app = client.application
+    task = Task.get_by_task_id(obj["taskId"])
+
+    with app.app_context():
+        expect(obj["taskUrl"]).to_equal(task.get_url())
+
     queue_job_id = obj["queueJobId"]
     hash_key = f"rq:job:{queue_job_id}"
-    app = client.application
 
     res = app.redis.exists(hash_key)
     expect(res).to_be_true()
@@ -58,7 +61,6 @@ def test_enqueue1(client):
     res = app.redis.hget(hash_key, "timeout")
     expect(res).to_equal("-1")
 
-    task = Task.get_by_task_id(obj["taskId"])
     expect(task).not_to_be_null()
     expect(task.jobs).not_to_be_empty()
 
@@ -72,7 +74,7 @@ def test_enqueue1(client):
     res = app.redis.lpop(q)
     expect(res).to_equal(queue_job_id)
 
-    with client.application.app_context():
+    with app.app_context():
         count = Task.objects.count()
         expect(count).to_equal(1)
 

--- a/tests/api/test_status.py
+++ b/tests/api/test_status.py
@@ -1,0 +1,15 @@
+# Standard Library
+from json import loads
+
+# 3rd Party
+from preggy import expect
+
+
+def test_status(client):
+    """Test the status response"""
+
+    resp = client.get("/status/")
+    expect(resp.status_code).to_equal(200)
+
+    data = loads(resp.data)
+    expect(data["containers"]['running']).to_length(0)

--- a/tests/api/test_task.py
+++ b/tests/api/test_task.py
@@ -1,0 +1,77 @@
+# Standard Library
+from json import loads
+
+# 3rd Party
+from preggy import expect
+
+# Fastlane
+from fastlane.models.task import Task
+
+
+def test_get_tasks(client):
+    """Test getting tasks"""
+    Task.create_task('my-task-1')
+    Task.create_task('my-task-2')
+    Task.create_task('my-task-3')
+
+    resp = client.get("/tasks")
+    expect(resp.status_code).to_equal(200)
+
+    data = loads(resp.data)    
+    expect(data["items"]).to_length(3)
+    expect(data["total"]).to_equal(3)
+    expect(data["page"]).to_equal(1)
+    expect(data["pages"]).to_equal(1)
+    expect(data["perPage"]).to_equal(3)
+    expect(data["hasNext"]).to_be_false()
+    expect(data["hasPrev"]).to_be_false()
+
+def test_get_tasks_data(client):
+    """Test getting tasks resource data"""
+    task = Task.create_task('my-task')
+
+    resp = client.get("/tasks")
+
+    data = loads(resp.data)
+    task_data = data["items"][0]
+
+    with client.application.app_context():
+        expect(task_data.keys()).to_equal(task.to_dict().keys())
+
+
+def test_get_tasks_pagination(client):
+    """Test getting tasks pagination"""
+    Task.create_task('my-task-1')
+    Task.create_task('my-task-2')
+    Task.create_task('my-task-3')
+    Task.create_task('my-task-4')
+
+    app = client.application
+    server_name = app.config['SERVER_NAME']
+
+    resp = client.get("/tasks?page=2")
+
+    data = loads(resp.data)
+    expect(data["total"]).to_equal(4)
+    expect(data["page"]).to_equal(2)
+    expect(data["hasNext"]).to_be_false()
+    expect(data["hasPrev"]).to_be_true()
+    expect(data["prevUrl"]).to_equal(f'http://{server_name}/tasks?page=1')
+    expect(data["nextUrl"]).to_be_null()
+
+
+def test_get_tasks_pagination_404_invalid_pages(client):
+    """
+    Test getting tasks pagination should respond 404 when page is invalid
+    """
+    resp1 = client.get("/tasks?page=asdasdas")
+    expect(resp1.status_code).to_equal(404)
+
+    resp2 = client.get("/tasks?page=1019021")
+    expect(resp2.status_code).to_equal(404)
+
+    resp3 = client.get("/tasks?page=0")
+    expect(resp3.status_code).to_equal(404)
+
+    resp4 = client.get("/tasks?page=-1")
+    expect(resp4.status_code).to_equal(404)

--- a/tests/models/test_task.py
+++ b/tests/models/test_task.py
@@ -37,6 +37,51 @@ def test_task_create2(client):
         Task.create_task("")
 
 
+def test_task_to_dict(client):
+    """Test to_dict"""
+    task = Task.create_task('my-task')
+    app = client.application
+    server_name = app.config['SERVER_NAME']
+
+    with app.app_context():
+        res = task.to_dict()
+
+    expect(res['taskId']).to_equal('my-task')
+
+    created_at = int(task.created_at.timestamp())
+    expect(int(res["createdAt"])).to_equal(created_at)
+
+    last_modified_at = int(task.last_modified_at.timestamp())
+    expect(int(res["lastModifiedAt"])).to_equal(last_modified_at)
+
+    expect(res["url"]).to_equal(f'http://{server_name}/tasks/my-task')
+    expect(res["jobsCount"]).to_equal(0)
+
+
+def test_task_get_tasks(client):
+    """Test getting tasks"""
+    Task.create_task(str(uuid4()))
+    Task.create_task(str(uuid4()))
+
+    tasks = Task.get_tasks()
+    expect(tasks.total).to_equal(2)
+
+
+def test_task_get_tasks_pagination(client):
+    """Test getting tasks pagination"""
+    Task.create_task(str(uuid4()))
+    Task.create_task(str(uuid4()))
+    Task.create_task(str(uuid4()))
+
+    tasks = Task.get_tasks(page=1, per_page=1)
+    expect(tasks.total).to_equal(3)
+    expect(tasks.pages).to_equal(3)
+    expect(tasks.items).to_length(1)
+
+    expect(tasks.has_next).to_be_true()
+    expect(tasks.has_prev).to_be_false()
+
+
 def test_task_get_by_task_id(client):
     """Test getting a task by task id"""
     task_id = str(uuid4())

--- a/tests/testing.conf
+++ b/tests/testing.conf
@@ -1,8 +1,14 @@
 DEBUG=True
 
-MONGODB_SETTINGS={
-    'host': 'mongomock://localhost',
-    'port': 10101,
-    'db': 'fastlane',
-    'serverSelectionTimeoutMS': 100,
+SERVER_NAME='localhost:10000'
+
+MONGODB_CONFIG='''
+{
+    "host": "mongomock://localhost",
+    "port": 10101,
+    "db": "fastlane",
+    "serverSelectionTimeoutMS": 100
 }
+'''
+
+PAGINATION_PER_PAGE=3


### PR DESCRIPTION
Hey @heynemann. This PR adds a new `/tasks` route to list all saved tasks on the api. I was thinking about pagination and filtering this route too, but I wanted to send this first as a start. What do you think?